### PR TITLE
Recursively convert images and don't write to source directory

### DIFF
--- a/lib/jekyll-webp/version.rb
+++ b/lib/jekyll-webp/version.rb
@@ -1,6 +1,6 @@
 module Jekyll
   module Webp
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
     # When modifying remember to issue a new tag command in git before committing, then push the new tag
     # git tag -a v0.1.0 -m "Gem v0.1.0"
     # git push origin --tags

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -17,7 +17,7 @@ module Jekyll
         # What is the OS and architecture specific executable name?
         exe_name = WebpExec.exe_name
 
-        # We need to locate the Gems bin path as we're currently running inside the
+        # We need to locate the Gems bin path as we're currently running inside the 
         # jekyll site working directory
         # http://stackoverflow.com/a/10083594/779521
         gem_spec = Gem::Specification.find_by_name("jekyll-webp")
@@ -27,8 +27,8 @@ module Jekyll
         full_path = File.join(gem_root, bin_path, exe_name)
 
         # Construct the full program call
-        cmd = "\"#{full_path}\" -quiet -mt -m 6 -pass 10 -q #{quality.to_s} \"#{input_file}\" -o \"#{output_file}\""
-
+        cmd = "\"#{full_path}\" -quiet -mt -q #{quality.to_s} \"#{input_file}\" -o \"#{output_file}\""
+        
         # Execute the command
         stdin, stdout, stderr = Open3.popen3(cmd)
 
@@ -60,7 +60,7 @@ module Jekyll
       end #function exe_name
 
     end #class WebpExec
-
+    
   end #module Webp
 
   module OS

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -17,7 +17,7 @@ module Jekyll
         # What is the OS and architecture specific executable name?
         exe_name = WebpExec.exe_name
 
-        # We need to locate the Gems bin path as we're currently running inside the 
+        # We need to locate the Gems bin path as we're currently running inside the
         # jekyll site working directory
         # http://stackoverflow.com/a/10083594/779521
         gem_spec = Gem::Specification.find_by_name("jekyll-webp")
@@ -27,8 +27,8 @@ module Jekyll
         full_path = File.join(gem_root, bin_path, exe_name)
 
         # Construct the full program call
-        cmd = "\"#{full_path}\" -quiet -mt -q #{quality.to_s} \"#{input_file}\" -o \"#{output_file}\""
-        
+        cmd = "\"#{full_path}\" -quiet -mt -m 6 -pass 10 -q #{quality.to_s} \"#{input_file}\" -o \"#{output_file}\""
+
         # Execute the command
         stdin, stdout, stderr = Open3.popen3(cmd)
 
@@ -60,7 +60,7 @@ module Jekyll
       end #function exe_name
 
     end #class WebpExec
-    
+
   end #module Webp
 
   module OS

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -5,7 +5,7 @@ module Jekyll
   module Webp
 
     #
-    # A static file to hold the generated webp image after generation
+    # A static file to hold the generated webp image after generation 
     # so that Jekyll will copy it into the site output directory
     class WebpFile < StaticFile
       def write(dest)
@@ -31,11 +31,11 @@ module Jekyll
 
         # If disabled then simply quit
         if !@config['enabled']
-          Jekyll.logger.info "WebP:", "Disabled in site.config."
+          Jekyll.logger.info "WebP:","Disabled in site.config."
           return
         end
 
-        Jekyll.logger.debug "WebP:", "Starting"
+        Jekyll.logger.debug "WebP:","Starting"
 
         # If the site destination directory has not yet been created then create it now. Otherwise, we cannot write our file there.
         Dir::mkdir(site.dest) if !File.directory? site.dest
@@ -45,55 +45,57 @@ module Jekyll
 
         # Iterate through every image in each of the image folders and create a webp image
         # if one has not been created already for that image.
-        for source in @config['img_dir']
-          source_full_path = File.join(site.source, source)
-          destination_full_path = File.join(site.dest, source)
-          FileUtils::mkdir_p destination_full_path
-          Jekyll.logger.info "WebP:", "Processing #{source_full_path}"
+        for imgdir in @config['img_dir']
+          imgdir_source = File.join(site.source, imgdir)
+          imgdir_destination = File.join(site.dest, imgdir)
+          FileUtils::mkdir_p(imgdir_destination)
+          Jekyll.logger.info "WebP:","Processing #{imgdir_source}"
+          
+          # handle only jpg, jpeg, png and gif
+          for imgfile in Dir[imgdir_source + "**/*.*"]
+              imgfile_relative_path = File.dirname(imgfile.sub(imgdir_source, ""))
+          
+              # Skip empty stuff
+              file_ext = File.extname(imgfile).downcase
 
-          for file_full_path in Dir[source_full_path + "/**/*.*"]
-            file_relative_path = file_full_path.sub(source_full_path, "")
+              # If the file is not one of the supported formats, exit early
+              next if !@config['formats'].include? file_ext
 
-            file_extension = File.extname(file_full_path).downcase
+              # TODO: Do an exclude check
+              
+              # Create the output file path
+              file_noext = File.basename(imgfile, file_ext)
+              outfile_filename = file_noext+ ".webp"
+              FileUtils::mkdir_p(imgdir_destination + imgfile_relative_path)
+              outfile_fullpath_webp = File.join(imgdir_destination + imgfile_relative_path, outfile_filename)
 
-            # If the file is not one of the supported formats, exit early
-            next if !@config['formats'].include? file_extension
+              # Check if the file already has a webp alternative?
+              # If we're force rebuilding all webp files then ignore the check
+              # also check the modified time on the files to ensure that the webp file
+              # is newer than the source file, if not then regenerate
+              next if !@config['regenerate'] && File.file?(outfile_fullpath_webp) &&
+                      File.mtime(outfile_fullpath_webp) > File.mtime(imgfile)      
+              
+              if( File.file?(outfile_fullpath_webp) && 
+                  File.mtime(outfile_fullpath_webp) <= File.mtime(imgfile) )
+                Jekyll.logger.info "WebP:", "Change to source image file #{imgfile} detected, regenerating WebP"
+              end
 
-            # TODO: Do an exclude check
-
-            # Create the output file path
-            file_no_extension = File.basename(file_full_path, file_extension)
-            relative_path = File.dirname(file_relative_path)
-            FileUtils::mkdir_p(destination_full_path + relative_path)
-            outfile_fullpath_webp = File.join(destination_full_path + relative_path, file_no_extension + ".webp")
-
-            # Check if the file already has a webp alternative?
-            # If we're force rebuilding all webp files then ignore the check
-            # also check the modified time on the files to ensure that the webp file
-            # is newer than the source file, if not then regenerate
-            next if !@config['regenerate'] && File.file?(outfile_fullpath_webp) &&
-                    File.mtime(outfile_fullpath_webp) > File.mtime(source_full_path)
-
-            if( File.file?(outfile_fullpath_webp) &&
-                File.mtime(outfile_fullpath_webp) <= File.mtime(source_full_path) )
-              Jekyll.logger.info "WebP:", "Change to source image file #{file} detected, regenerating WebP"
-            end
-
-            Jekyll.logger.info "WebP:", "Generating #{outfile_fullpath_webp}"
-            # Generate the file
-            WebpExec.run(@config['quality'], file_full_path, outfile_fullpath_webp)
-
-            # Keep the webp file from being cleaned by Jekyll
-            site.static_files << WebpFile.new(site, site.dest, source, outfile_fullpath_webp)
-            file_count += 1
-          end # file_full_path
+              # Generate the file
+              WebpExec.run(@config['quality'], imgfile, outfile_fullpath_webp)
+              
+              # Keep the webp file from being cleaned by Jekyll
+              site.static_files << WebpFile.new(site, site.dest, imgdir, outfile_fullpath_webp)
+              file_count += 1
+              
+          end # dir.foreach
         end # img_dir
 
-        Jekyll.logger.info "WebP:", "Generator Complete: #{file_count} file(s) generated"
+        Jekyll.logger.info "WebP:","Generator Complete: #{file_count} file(s) generated"
 
       end #function generate
 
     end #class WebPGenerator
-
+    
   end #module Webp
 end #module Jekyll

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -1,10 +1,11 @@
 require 'jekyll/document'
+require 'fileutils'
 
 module Jekyll
   module Webp
 
     #
-    # A static file to hold the generated webp image after generation 
+    # A static file to hold the generated webp image after generation
     # so that Jekyll will copy it into the site output directory
     class WebpFile < StaticFile
       def write(dest)
@@ -30,11 +31,11 @@ module Jekyll
 
         # If disabled then simply quit
         if !@config['enabled']
-          Jekyll.logger.info "WebP:","Disabled in site.config."
+          Jekyll.logger.info "WebP:", "Disabled in site.config."
           return
         end
 
-        Jekyll.logger.debug "WebP:","Starting"
+        Jekyll.logger.debug "WebP:", "Starting"
 
         # If the site destination directory has not yet been created then create it now. Otherwise, we cannot write our file there.
         Dir::mkdir(site.dest) if !File.directory? site.dest
@@ -44,57 +45,55 @@ module Jekyll
 
         # Iterate through every image in each of the image folders and create a webp image
         # if one has not been created already for that image.
-        for imgdir in @config['img_dir']
-          imgdir_source = File.join(site.source, imgdir)
-          Jekyll.logger.info "WebP:","Processing #{imgdir_source}"
-          
-          # handle only jpg, jpeg, png and gif
-          Dir.foreach(imgdir_source) do |imgfile|
-          
-              # Skip empty stuff
-              next if imgfile == '.' or imgfile == '..'
-              file_ext = File.extname(imgfile).downcase
+        for source in @config['img_dir']
+          source_full_path = File.join(site.source, source)
+          destination_full_path = File.join(site.dest, source)
+          FileUtils::mkdir_p destination_full_path
+          Jekyll.logger.info "WebP:", "Processing #{source_full_path}"
 
-              # If the file is not one of the supported formats, exit early
-              next if !@config['formats'].include? file_ext
+          for file_full_path in Dir[source_full_path + "/**/*.*"]
+            file_relative_path = file_full_path.sub(source_full_path, "")
 
-              # TODO: Do an exclude check
-              
-              # Create the output file path
-              file_noext = File.basename(imgfile, file_ext)
-              outfile_filename = file_noext+ ".webp"
-              outfile_fullpath_webp = File.join(imgdir_source, outfile_filename)
+            file_extension = File.extname(file_full_path).downcase
 
-              # Create the full input file name
-              infile_fullpath = File.join(imgdir_source, imgfile)
-          
-              # Check if the file already has a webp alternative?
-              # If we're force rebuilding all webp files then ignore the check
-              # also check the modified time on the files to ensure that the webp file
-              # is newer than the source file, if not then regenerate
-              next if !@config['regenerate'] && File.file?(outfile_fullpath_webp) &&
-                      File.mtime(outfile_fullpath_webp) > File.mtime(infile_fullpath)      
-              
-              if( File.file?(outfile_fullpath_webp) && 
-                  File.mtime(outfile_fullpath_webp) <= File.mtime(infile_fullpath) )
-                Jekyll.logger.info "WebP:", "Change to source image file #{imgfile} detected, regenerating WebP"
-              end
+            # If the file is not one of the supported formats, exit early
+            next if !@config['formats'].include? file_extension
 
-              # Generate the file
-              WebpExec.run(@config['quality'], infile_fullpath, outfile_fullpath_webp)
-              
-              # Keep the webp file from being cleaned by Jekyll
-              site.static_files << WebpFile.new(site, site.dest, imgdir, outfile_filename)
-              file_count += 1
-              
-          end # dir.foreach
+            # TODO: Do an exclude check
+
+            # Create the output file path
+            file_no_extension = File.basename(file_full_path, file_extension)
+            relative_path = File.dirname(file_relative_path)
+            FileUtils::mkdir_p(destination_full_path + relative_path)
+            outfile_fullpath_webp = File.join(destination_full_path + relative_path, file_no_extension + ".webp")
+
+            # Check if the file already has a webp alternative?
+            # If we're force rebuilding all webp files then ignore the check
+            # also check the modified time on the files to ensure that the webp file
+            # is newer than the source file, if not then regenerate
+            next if !@config['regenerate'] && File.file?(outfile_fullpath_webp) &&
+                    File.mtime(outfile_fullpath_webp) > File.mtime(source_full_path)
+
+            if( File.file?(outfile_fullpath_webp) &&
+                File.mtime(outfile_fullpath_webp) <= File.mtime(source_full_path) )
+              Jekyll.logger.info "WebP:", "Change to source image file #{file} detected, regenerating WebP"
+            end
+
+            Jekyll.logger.info "WebP:", "Generating #{outfile_fullpath_webp}"
+            # Generate the file
+            WebpExec.run(@config['quality'], file_full_path, outfile_fullpath_webp)
+
+            # Keep the webp file from being cleaned by Jekyll
+            site.static_files << WebpFile.new(site, site.dest, source, outfile_fullpath_webp)
+            file_count += 1
+          end # file_full_path
         end # img_dir
 
-        Jekyll.logger.info "WebP:","Generator Complete: #{file_count} file(s) generated"
+        Jekyll.logger.info "WebP:", "Generator Complete: #{file_count} file(s) generated"
 
       end #function generate
 
     end #class WebPGenerator
-    
+
   end #module Webp
 end #module Jekyll


### PR DESCRIPTION
I have this proposal, I'm happy to discuss it otherwise I'll keep working on my fork! :)

- I thought was handy to recursively convert images.
- it's probably not a good idea to write in the source folder. My scenario is that I have some png files (original pictures) in `/assets/something` that I want to serve as wepb from `_site/assets/something`. But I don't want to have the original png files in the `_site` directory, so this kind of fixes that.