### PR TITLE
Some features and fixes

### DIFF
--- a/lib/jekyll-webp/defaults.rb
+++ b/lib/jekyll-webp/defaults.rb
@@ -6,15 +6,12 @@ module Jekyll
     DEFAULT = {
       'enabled'   => false,
 
-      # The flags to pass to the webp binary. For a list of valid parameters check here:
+      # The quality of the webp conversion 0 to 100 (where 100 is least lossy)
+      'quality'   => 75,
+
+      # Other flags to pass to the webp binary. For a list of valid parameters check here:
       # https://developers.google.com/speed/webp/docs/cwebp#options
-      'flags'     => "-q 75",
-
-      # For best lossy compression use
-      # 'flags'     => "-q 100 -m 6 -pass 10 -af",
-
-      # For best lossless compression use
-      # 'flags'     => "-q 100 -lossless -z 9",
+      'flags'     => "-m 4 -pass 4 -af",
 
       # List of directories containing images to optimize, Nested directories will not be checked
       'img_dir'   => ["/img"],

--- a/lib/jekyll-webp/defaults.rb
+++ b/lib/jekyll-webp/defaults.rb
@@ -10,6 +10,12 @@ module Jekyll
       # https://developers.google.com/speed/webp/docs/cwebp#options
       'flags'     => "-q 75",
 
+      # For best lossy compression use
+      # 'flags'     => "-q 100 -m 6 -pass 10 -af",
+
+      # For best lossless compression use
+      # 'flags'     => "-q 100 -lossless -z 9",
+
       # List of directories containing images to optimize, Nested directories will not be checked
       'img_dir'   => ["/img"],
 

--- a/lib/jekyll-webp/defaults.rb
+++ b/lib/jekyll-webp/defaults.rb
@@ -6,8 +6,9 @@ module Jekyll
     DEFAULT = {
       'enabled'   => false,
 
-      # The quality of the webp conversion 0 to 100 (where 100 is least lossy)
-      'quality'   => 75,
+      # The flags to pass to the webp binary. For a list of valid parameters check here:
+      # https://developers.google.com/speed/webp/docs/cwebp#options
+      'flags'     => "-q 75",
 
       # List of directories containing images to optimize, Nested directories will not be checked
       'img_dir'   => ["/img"],

--- a/lib/jekyll-webp/version.rb
+++ b/lib/jekyll-webp/version.rb
@@ -1,6 +1,6 @@
 module Jekyll
   module Webp
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
     # When modifying remember to issue a new tag command in git before committing, then push the new tag
     # git tag -a v0.1.0 -m "Gem v0.1.0"
     # git push origin --tags

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -17,7 +17,7 @@ module Jekyll
         # What is the OS and architecture specific executable name?
         exe_name = WebpExec.exe_name
 
-        # We need to locate the Gems bin path as we're currently running inside the
+        # We need to locate the Gems bin path as we're currently running inside the 
         # jekyll site working directory
         # http://stackoverflow.com/a/10083594/779521
         gem_spec = Gem::Specification.find_by_name("jekyll-webp")
@@ -28,13 +28,13 @@ module Jekyll
 
         # Construct the full program call
         cmd = "\"#{full_path}\" -quiet -mt #{flags} \"#{input_file}\" -o \"#{output_file}\""
-
+        
         # Execute the command
         exit_code = 0
         error = ""
         output = ""
         Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-          stdin.close # wo don't pass any input to the process
+          stdin.close # we don't pass any input to the process
           output = stdout.gets
           error = stderr.gets
           exit_code = wait_thr.value
@@ -72,7 +72,7 @@ module Jekyll
       end #function exe_name
 
     end #class WebpExec
-
+    
   end #module Webp
 
   module OS

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -17,7 +17,7 @@ module Jekyll
         # What is the OS and architecture specific executable name?
         exe_name = WebpExec.exe_name
 
-        # We need to locate the Gems bin path as we're currently running inside the 
+        # We need to locate the Gems bin path as we're currently running inside the
         # jekyll site working directory
         # http://stackoverflow.com/a/10083594/779521
         gem_spec = Gem::Specification.find_by_name("jekyll-webp")
@@ -27,13 +27,25 @@ module Jekyll
         full_path = File.join(gem_root, bin_path, exe_name)
 
         # Construct the full program call
-        cmd = "\"#{full_path}\" -quiet -mt \"#{flags}\" \"#{input_file}\" -o \"#{output_file}\""
-        
+        cmd = "\"#{full_path}\" -quiet -mt #{flags} \"#{input_file}\" -o \"#{output_file}\""
+
         # Execute the command
-        stdin, stdout, stderr = Open3.popen3(cmd)
+        exit_code = 0
+        error = ""
+        output = ""
+        Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+          stdin.close # wo don't pass any input to the process
+          output = stdout.gets
+          error = stderr.gets
+          exit_code = wait_thr.value
+        end
+
+        if exit_code != 0
+          Jekyll.logger.error("WebP:","cwebp returned #{exit_code} with error #{error}")
+        end
 
         # Return any captured return value
-        return [stdin, stdout, stderr]
+        return [output, error]
       end #function run
 
       #
@@ -60,7 +72,7 @@ module Jekyll
       end #function exe_name
 
     end #class WebpExec
-    
+
   end #module Webp
 
   module OS

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -9,7 +9,7 @@ module Jekyll
       # Runs the WebP executable for the given input parameters
       # the function detects the OS platform and architecture automatically
       #
-      def self.run(quality, input_file, output_file)
+      def self.run(flags, input_file, output_file)
 
         # What is the path to the execs inside the gem? perhaps just bin/?
         bin_path = "bin/"
@@ -27,7 +27,7 @@ module Jekyll
         full_path = File.join(gem_root, bin_path, exe_name)
 
         # Construct the full program call
-        cmd = "\"#{full_path}\" -quiet -mt -q #{quality.to_s} \"#{input_file}\" -o \"#{output_file}\""
+        cmd = "\"#{full_path}\" -quiet -mt \"#{flags}\" \"#{input_file}\" -o \"#{output_file}\""
         
         # Execute the command
         stdin, stdout, stderr = Open3.popen3(cmd)

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -9,7 +9,7 @@ module Jekyll
       # Runs the WebP executable for the given input parameters
       # the function detects the OS platform and architecture automatically
       #
-      def self.run(flags, input_file, output_file)
+      def self.run(quality, flags, input_file, output_file)
 
         # What is the path to the execs inside the gem? perhaps just bin/?
         bin_path = "bin/"
@@ -27,7 +27,7 @@ module Jekyll
         full_path = File.join(gem_root, bin_path, exe_name)
 
         # Construct the full program call
-        cmd = "\"#{full_path}\" -quiet -mt #{flags} \"#{input_file}\" -o \"#{output_file}\""
+        cmd = "\"#{full_path}\" -quiet -mt -q #{quality.to_s} #{flags} \"#{input_file}\" -o \"#{output_file}\""
         
         # Execute the command
         exit_code = 0
@@ -41,7 +41,8 @@ module Jekyll
         end
 
         if exit_code != 0
-          Jekyll.logger.error("WebP:","cwebp returned #{exit_code} with error #{error}")
+          Jekyll.logger.error("WebP:","Conversion for image #{input_file} failed, no webp version could be created for this image")
+          Jekyll.logger.debug("WebP:","cwebp returned #{exit_code} with error #{error}")
         end
 
         # Return any captured return value

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -69,28 +69,25 @@ module Jekyll
               FileUtils::mkdir_p(imgdir_destination + imgfile_relative_path)
               outfile_fullpath_webp = File.join(imgdir_destination + imgfile_relative_path, outfile_filename)
 
-              # Keep the webp file from being cleaned by Jekyll
-              site.static_files << WebpFile.new(site,
-                                                site.dest,
-                                                File.join(imgdir, imgfile_relative_path),
-                                                outfile_filename)
-
               # Check if the file already has a webp alternative?
               # If we're force rebuilding all webp files then ignore the check
               # also check the modified time on the files to ensure that the webp file
               # is newer than the source file, if not then regenerate
-              next if !@config['regenerate'] && File.file?(outfile_fullpath_webp) &&
-                      File.mtime(outfile_fullpath_webp) > File.mtime(imgfile)      
-              
-              if( File.file?(outfile_fullpath_webp) && 
-                  File.mtime(outfile_fullpath_webp) <= File.mtime(imgfile) )
+              if @config['regenerate'] || !File.file?(outfile_fullpath_webp) ||
+                 File.mtime(outfile_fullpath_webp) <= File.mtime(imgfile)
                 Jekyll.logger.info "WebP:", "Change to source image file #{imgfile} detected, regenerating WebP"
-              end
 
-              # Generate the file
-              WebpExec.run(@config['flags'], imgfile, outfile_fullpath_webp)
-              file_count += 1
-              
+                # Generate the file
+                WebpExec.run(@config['quality'], @config['flags'], imgfile, outfile_fullpath_webp)
+                file_count += 1
+              end
+              if File.file?(outfile_fullpath_webp)
+                # Keep the webp file from being cleaned by Jekyll
+                site.static_files << WebpFile.new(site,
+                                                  site.dest,
+                                                  File.join(imgdir, imgfile_relative_path),
+                                                  outfile_filename)
+              end
           end # dir.foreach
         end # img_dir
 

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -82,7 +82,7 @@ module Jekyll
               end
 
               # Generate the file
-              WebpExec.run(@config['quality'], imgfile, outfile_fullpath_webp)
+              WebpExec.run(@config['flags'], imgfile, outfile_fullpath_webp)
               
               # Keep the webp file from being cleaned by Jekyll
               site.static_files << WebpFile.new(site, site.dest, imgdir, outfile_fullpath_webp)

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -69,6 +69,12 @@ module Jekyll
               FileUtils::mkdir_p(imgdir_destination + imgfile_relative_path)
               outfile_fullpath_webp = File.join(imgdir_destination + imgfile_relative_path, outfile_filename)
 
+              # Keep the webp file from being cleaned by Jekyll
+              site.static_files << WebpFile.new(site,
+                                                site.dest,
+                                                File.join(imgdir, imgfile_relative_path),
+                                                outfile_filename)
+
               # Check if the file already has a webp alternative?
               # If we're force rebuilding all webp files then ignore the check
               # also check the modified time on the files to ensure that the webp file
@@ -83,9 +89,6 @@ module Jekyll
 
               # Generate the file
               WebpExec.run(@config['flags'], imgfile, outfile_fullpath_webp)
-              
-              # Keep the webp file from being cleaned by Jekyll
-              site.static_files << WebpFile.new(site, site.dest, imgdir, outfile_fullpath_webp)
               file_count += 1
               
           end # dir.foreach


### PR DESCRIPTION
There was a bug (not sure if introduced with the previous PR) where `serve --watch` does not keep track correctly of the generated files. This happens because of the `next if ...` in the inner loop in `webpGenerator`.

Another problem was that `webpExec` was not waiting for the subprocesses to finish.

Finally I propose to pass arbitrary flags to the `cwebp` process, that is probably also easier to mantain instead of trying to map the CLI to yaml.