### PR TITLE
Enable appending extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ webp:
   # List of files or directories to exclude
   # e.g. custom or hand generated webp conversion files
   exclude: []
+
+  # append '.webp' to filename after original extension rather than replacing it.
+  # Default transforms `image.png` to `image.webp`, while changing to true transforms `image.png` to `image.png.webp`
+  append_ext: false
 ############################################################
 ```
 

--- a/lib/jekyll-webp/defaults.rb
+++ b/lib/jekyll-webp/defaults.rb
@@ -19,7 +19,12 @@ module Jekyll
       # add ".gif" to the format list to generate webp for animated gifs as well
       'formats'   => [".jpeg", ".jpg", ".png", ".tiff"],
 
-      # File extensions for animated gif files 
+      # append .webp to existing extension instead of replacing it
+      # (Enables more efficient nginx rules.
+      # See http://www.lazutkin.com/blog/2014/02/23/serve-files-with-nginx-conditionally/)
+      'append_ext' => false,
+
+      # File extensions for animated gif files
       'gifs'      => [".gif"],
 
       # Set to true to always regenerate existing webp files
@@ -33,7 +38,7 @@ module Jekyll
       # e.g. custom or hand generated webp conversion files
       'exclude'   => [],
 
-      # List of files or directories to explicitly include 
+      # List of files or directories to explicitly include
       # e.g. single files outside of the main image directories
       'include'   => []
     }

--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -5,7 +5,7 @@ module Jekyll
   module Webp
 
     #
-    # A static file to hold the generated webp image after generation 
+    # A static file to hold the generated webp image after generation
     # so that Jekyll will copy it into the site output directory
     class WebpFile < StaticFile
       def write(dest)
@@ -50,11 +50,11 @@ module Jekyll
           imgdir_destination = File.join(site.dest, imgdir)
           FileUtils::mkdir_p(imgdir_destination)
           Jekyll.logger.info "WebP:","Processing #{imgdir_source}"
-          
+
           # handle only jpg, jpeg, png and gif
           for imgfile in Dir[imgdir_source + "**/*.*"]
               imgfile_relative_path = File.dirname(imgfile.sub(imgdir_source, ""))
-          
+
               # Skip empty stuff
               file_ext = File.extname(imgfile).downcase
 
@@ -62,10 +62,14 @@ module Jekyll
               next if !@config['formats'].include? file_ext
 
               # TODO: Do an exclude check
-              
+
               # Create the output file path
-              file_noext = File.basename(imgfile, file_ext)
-              outfile_filename = file_noext+ ".webp"
+              outfile_filename = if @config['append_ext']
+                File.basename(imgfile) + '.webp'
+              else
+                file_noext = File.basename(imgfile, file_ext)
+                file_noext + ".webp"
+              end
               FileUtils::mkdir_p(imgdir_destination + imgfile_relative_path)
               outfile_fullpath_webp = File.join(imgdir_destination + imgfile_relative_path, outfile_filename)
 
@@ -96,6 +100,6 @@ module Jekyll
       end #function generate
 
     end #class WebPGenerator
-    
+
   end #module Webp
 end #module Jekyll


### PR DESCRIPTION
Adds a config option to change the naming convention for generating files to append `.webp` instead of replacing the existing extension.

Justification: This allows for a very efficient server config (at least on nginx) for conditionally serving webp. See: http://www.lazutkin.com/blog/2014/02/23/serve-files-with-nginx-conditionally/