### PR TITLE
Add slash to search pattern if missing

### DIFF
--- a/lib/jekyll-webp/webpGenerator.rb
+++ b/lib/jekyll-webp/webpGenerator.rb
@@ -50,9 +50,15 @@ module Jekyll
           imgdir_destination = File.join(site.dest, imgdir)
           FileUtils::mkdir_p(imgdir_destination)
           Jekyll.logger.info "WebP:","Processing #{imgdir_source}"
-          
+
+          # append a / if missing
+          imgdir_search_prefix = imgdir_source
+          if !imgdir_source.end_with?("/") then
+            imgdir_search_prefix = imgdir_source + "/"
+          end
+
           # handle only jpg, jpeg, png and gif
-          for imgfile in Dir[imgdir_source + "**/*.*"]
+          for imgfile in Dir[imgdir_search_prefix + "**/*.*"]
               imgfile_relative_path = File.dirname(imgfile.sub(imgdir_source, ""))
           
               # Skip empty stuff


### PR DESCRIPTION
When specifying an image directory without a trailing slash, the search pattern won't pick up images in subdirectories because a wrong pattern is generated (e.g. `/images**/*.*` vs `/images/**/*.*`).

If a slash is missing, it is now appended before building the search pattern.

This should also fix #6 
