### PR TITLE
Extended the library with new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-[![Gem Version](https://img.shields.io/gem/v/jekyll-webp.svg)](https://rubygems.org/gems/jekyll-webp)
-[![Gem](https://img.shields.io/gem/dt/jekyll-webp.svg)](https://rubygems.org/gems/jekyll-webp)
-[![Join the chat at https://gitter.im/jekyll-webp/Lobby](https://badges.gitter.im/jekyll-webp/Lobby.svg)](https://gitter.im/jekyll-webp/Lobby)
-[![Dependency Status](https://gemnasium.com/badges/github.com/sverrirs/jekyll-webp.svg)](https://gemnasium.com/github.com/sverrirs/jekyll-webp)
-[![Code Climate](https://codeclimate.com/github/sverrirs/jekyll-webp/badges/gpa.svg)](https://codeclimate.com/github/sverrirs/jekyll-webp)
-[![security](https://hakiri.io/github/sverrirs/jekyll-webp/master.svg)](https://hakiri.io/github/sverrirs/jekyll-webp/master)
-
-# WebP Generator for Jekyll
+# WebP Generator for Jekyll (Extended)
 WebP Image Generator for Jekyll Sites can automatically generate WebP images for all images on your static site and serve them when possible. View on [rubygems.org](https://rubygems.org/gems/jekyll-webp).
 
-> Read more about this tool on my blog at <a href="https://blog.sverrirs.com/2016/06/webp-generator-for-jekyll-sites.html" target="_blank">blog.sverrirs.com</a>
+**This repo is an extended version of it's fork `jekyll-webp`**
 
-## Installation
+## Additional Features
+- Generate thumbnails in webp format
+- Generate small images (.5x) in webp format
+- Specifiy output sub directory for webp images
+
+## Additional Dependencies
+- fastimage
+
+## Installation instructions
+```
+group :jekyll_plugins do
+  gem 'jekyll-webp', git: 'https://github.com/Rohithzr/jekyll-webp-ext', branch: 'extend'
+end
+```
+
+## Original installation instructions
 
 ```
 gem install jekyll-webp
@@ -63,6 +71,22 @@ webp:
   # append '.webp' to filename after original extension rather than replacing it.
   # Default transforms `image.png` to `image.webp`, while changing to true transforms `image.png` to `image.png.webp`
   append_ext: false
+  
+  ##### Extended Features start
+  # Use a different output subdirectory
+  # e.g. value of "/optimized" will create files at "/source/optimized" instead of "/source"
+  output_img_sub_dir: "/optimized" # default ""
+  
+  # Generate thumbnails
+  thumbs: true
+  
+  # Thumbnails sub directory
+  thumbs_dir: "/thumbs"
+
+  # generate .5x images
+  generate_50p: true
+  
+  ##### Extended Features end
 ############################################################
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WebP Generator for Jekyll (Extended)
 WebP Image Generator for Jekyll Sites can automatically generate WebP images for all images on your static site and serve them when possible. View on [rubygems.org](https://rubygems.org/gems/jekyll-webp).
 
-**This repo is an extended version of it's fork `jekyll-webp`**
+**This repo is an extended version of it's fork [https://github.com/sverrirs/jekyll-webp](`jekyll-webp`)**
 
 ## Additional Features
 - Generate thumbnails in webp format

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WebP Generator for Jekyll (Extended)
 WebP Image Generator for Jekyll Sites can automatically generate WebP images for all images on your static site and serve them when possible. View on [rubygems.org](https://rubygems.org/gems/jekyll-webp).
 
-**This repo is an extended version of it's fork [https://github.com/sverrirs/jekyll-webp](`jekyll-webp`)**
+**This repo is an extended version of it's fork [`jekyll-webp`](https://github.com/sverrirs/jekyll-webp)**
 
 ## Additional Features
 - Generate thumbnails in webp format

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WebP Generator for Jekyll (Extended)
 WebP Image Generator for Jekyll Sites can automatically generate WebP images for all images on your static site and serve them when possible. View on [rubygems.org](https://rubygems.org/gems/jekyll-webp).
 
-**This repo is an extended version of it's fork [`jekyll-webp`](https://github.com/sverrirs/jekyll-webp)**
+**This repo is an extended version of it's fork [jekyll-webp](https://github.com/sverrirs/jekyll-webp)**
 
 ## Additional Features
 - Generate thumbnails in webp format

--- a/jekyll-webp.gemspec
+++ b/jekyll-webp.gemspec
@@ -20,9 +20,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "fastimage", '>= 2.0.0'
+
   spec.add_development_dependency "jekyll", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 1.5"
   spec.add_development_dependency "minitest", '~> 5.4', '>= 5.4.3'
-  spec.add_development_dependency "fastimage", '>= 2.0.0'
+  
 end

--- a/jekyll-webp.gemspec
+++ b/jekyll-webp.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.name          = "jekyll-webp"
   spec.version       = Jekyll::Webp::VERSION
   spec.platform      = Gem::Platform::RUBY
-  spec.date          = DateTime.now.strftime('%Y-%m-%d')
+  # spec.date          = DateTime.now.strftime('%Y-%m-%d')
   spec.authors       = ["Sverrir Sigmundarson"]
   spec.email         = ["jekyll@sverrirs.com"]
   spec.homepage      = "https://github.com/sverrirs/jekyll-webp"
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 1.5"
   spec.add_development_dependency "minitest", '~> 5.4', '>= 5.4.3'
+  spec.add_development_dependency "fastimage", '>= 2.0.0'
 end

--- a/jekyll-webp.gemspec
+++ b/jekyll-webp.gemspec
@@ -1,11 +1,12 @@
 # coding: utf-8
 require_relative 'lib/jekyll-webp/version'
+require "date"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-webp"
   spec.version       = Jekyll::Webp::VERSION
   spec.platform      = Gem::Platform::RUBY
-  # spec.date          = DateTime.now.strftime('%Y-%m-%d')
+  spec.date          = DateTime.now.strftime('%Y-%m-%d')
   spec.authors       = ["Sverrir Sigmundarson"]
   spec.email         = ["jekyll@sverrirs.com"]
   spec.homepage      = "https://github.com/sverrirs/jekyll-webp"

--- a/lib/jekyll-webp/defaults.rb
+++ b/lib/jekyll-webp/defaults.rb
@@ -43,7 +43,20 @@ module Jekyll
 
       # List of files or directories to explicitly include
       # e.g. single files outside of the main image directories
-      'include'   => []
+      'include'   => [],
+
+      # Use a different output subdirectory
+      # e.g. value of "/optimized" will create files at "/source/optimized" instead of "/source"
+      'output_img_sub_dir'   => "",
+
+      # Generate thumbnails
+      'thumbs'   => false,
+
+      # Thumbnails sub directory
+      'thumbs_dir'   => "/thumbs",
+      
+      # generate .5x images
+      'generate_50p'   => false
     }
 
   end # module Webp

--- a/lib/jekyll-webp/version.rb
+++ b/lib/jekyll-webp/version.rb
@@ -1,6 +1,6 @@
 module Jekyll
   module Webp
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
     # When modifying remember to issue a new tag command in git before committing, then push the new tag
     # git tag -a v1.0.0 -m "Gem v1.0.0"
     # git push origin --tags

--- a/lib/jekyll-webp/webpExec.rb
+++ b/lib/jekyll-webp/webpExec.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'fastimage'
 
 module Jekyll
   module Webp
@@ -41,12 +42,13 @@ module Jekyll
           stdin.close # we don't pass any input to the process
           output = stdout.gets
           error = stderr.gets
+
           exit_code = wait_thr.value
         end
 
         if exit_code != 0
-          Jekyll.logger.error("WebP:","Conversion for image #{input_file} failed, no webp version could be created for this image")
-          Jekyll.logger.debug("WebP:","cwebp returned #{exit_code} with error #{error}")
+          # Jekyll.logger.error("WebP:","Conversion for image #{input_file} failed, no webp version could be created for this image")
+          Jekyll.logger.error("WebP:","cwebp returned #{exit_code} with error #{error}")
         end
 
         # Return any captured return value


### PR DESCRIPTION
For my own use I have extended the library with a few useful scenarios. I am not sure of the author of the original repo would want to extend the repo itself because it kind of goes beyond the purview of the library itself. But I am still happy to contribute and assist.

For anyone curious to try the extended version, below are the details.

## Additional Features
- Generate thumbnails in webp format
- Generate small images (.5x) in webp format
- Specifiy output sub directory for webp images

## Additional Dependencies
- fastimage

## Installation instructions
```
group :jekyll_plugins do
  gem 'jekyll-webp', git: 'https://github.com/Rohithzr/jekyll-webp-ext', branch: 'extend'
end
```

## Sample config
```
webp:
  enabled: true
  quality: 100
  thumbs: true
  img_dir: ["/blog_images"]
  output_img_sub_dir: "/optimized"
  thumbs_dir: "/thumbnails"
  formats: [".jpeg", ".jpg", ".png", ".tiff"]
  regenerate: true
  generate_50p: true
```

Happy to hear back from you. :) 